### PR TITLE
fix: filter out small polygons from multipolygon isochrone geometry

### DIFF
--- a/isochrones/isochrones.py
+++ b/isochrones/isochrones.py
@@ -20,8 +20,7 @@ def calculate_isochrones(
     area_threshold: float = 1e-6,
 ) -> gpd.GeoDataFrame:
     """
-    Calculate isochrones for a given location and time. The isochrones returned are non-overlapping polygons
-    representing areas reachable within specified cutoff times.
+    Calculate isochrones for a given location and time.
 
     Args:
         lat (float): Latitude of the location.
@@ -36,7 +35,8 @@ def calculate_isochrones(
         router (str, optional): The router ID to use for the request, defaulting to "default".
         crs (str, optional): The coordinate reference system for the output GeoDataFrame, defaulting to "EPSG:4326".
         overlap (bool, optional): Whether to return overlapping isochrones or non-overlapping ones. Defaults to True.
-        area_threshold (float, optional): Minimum area threshold to filter out small polygons within the isochrones. Defaults to 1e-6.
+        area_threshold (float, optional): Minimum area threshold to filter out small polygons within the isochrones, expressed in the area units of the
+        specified CRS (e.g. degrees squared for EPSG:4326). Defaults to 1e-6.
     Returns:
         gpd.GeoDataFrame: A GeoDataFrame containing the isochrones.
     """
@@ -77,34 +77,64 @@ def calculate_isochrones(
     isochrone = gpd.GeoDataFrame.from_features(r.json()["features"])
     isochrone.crs = crs
 
-    def filter_small_polygons(
-        geom: Union[MultiPolygon, Polygon, None], min_area: float
-    ) -> Union[MultiPolygon, Polygon, None]:
-        if isinstance(geom, MultiPolygon):
-            # Only filter out if there is more than one polygon
-            if len(geom.geoms) == 1:
-                return geom
-            filtered = [p for p in geom.geoms if p.area >= min_area]
-            if not filtered:
-                return None  # Or Polygon() for empty
-            return MultiPolygon(filtered)
-        elif isinstance(geom, Polygon):
-            return geom
-        return geom
-
     isochrone["geometry"] = isochrone["geometry"].map(
         lambda geom: filter_small_polygons(geom, area_threshold)
     )
 
-    if not overlap and len(cutoffSec) > 1:
-        # Sort by time to ensure correct order for difference calculation
-        isochrone = isochrone.sort_values("time").reset_index(drop=True)
-        # Iterate from the largest isochrone down to the second smallest
-        for i in range(len(isochrone) - 1, 0, -1):
-            # Subtract the smaller isochrone from the larger one
-            isochrone.at[i, "geometry"] = isochrone.loc[i, "geometry"].difference(
-                isochrone.loc[i - 1, "geometry"]
-            )
+    if not overlap:
+        isochrone = make_non_overlapping(isochrone)
+
+    return isochrone
+
+
+def filter_small_polygons(
+    geom: Union[MultiPolygon, Polygon, None], min_area: float
+) -> Union[MultiPolygon, Polygon]:
+    """
+    Filter out small polygons from a MultiPolygon geometry based on an area threshold.
+
+    Args:
+        geom (Union[MultiPolygon, Polygon, None]): The geometry to filter.
+        min_area (float): The minimum area threshold.
+
+    Returns:
+        Union[MultiPolygon, Polygon, None]: The filtered geometry.
+    """
+    if geom is None:
+        return Polygon()  # Return an empty polygon if geometry is None
+    if isinstance(geom, MultiPolygon):
+        # Only filter out if there is more than one polygon
+        if len(geom.geoms) == 1:
+            return geom
+        filtered = [p for p in geom.geoms if p.area >= min_area]
+        if not filtered:
+            return Polygon()
+        return MultiPolygon(filtered)
+
+    return geom
+
+
+def make_non_overlapping(isochrone: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    """
+    Make isochrones non-overlapping by subtracting smaller availability zones from larger ones.
+
+    Args:
+        isochrone (gpd.GeoDataFrame): The isochrones GeoDataFrame.
+
+    Returns:
+        gpd.GeoDataFrame: The non-overlapping isochrones.
+    """
+    if len(isochrone) <= 1:
+        return isochrone
+
+    # Sort by time to ensure correct order for difference calculation
+    isochrone = isochrone.sort_values("time").reset_index(drop=True)
+    # Iterate from the largest isochrone down to the second smallest
+    for i in range(len(isochrone) - 1, 0, -1):
+        # Subtract the smaller isochrone from the larger one
+        isochrone.at[i, "geometry"] = isochrone.loc[i, "geometry"].difference(
+            isochrone.loc[i - 1, "geometry"]
+        )
 
     return isochrone
 

--- a/isochrones/isochrones.py
+++ b/isochrones/isochrones.py
@@ -2,6 +2,7 @@ import datetime
 from typing import Dict, List, Union, Optional
 import requests
 import geopandas as gpd
+from shapely.geometry import MultiPolygon, Polygon
 
 
 def calculate_isochrones(
@@ -16,6 +17,7 @@ def calculate_isochrones(
     router: str = "default",
     crs: str = "EPSG:4326",
     overlap: bool = True,
+    area_threshold: float = 1e-6,
 ) -> gpd.GeoDataFrame:
     """
     Calculate isochrones for a given location and time. The isochrones returned are non-overlapping polygons
@@ -34,7 +36,7 @@ def calculate_isochrones(
         router (str, optional): The router ID to use for the request, defaulting to "default".
         crs (str, optional): The coordinate reference system for the output GeoDataFrame, defaulting to "EPSG:4326".
         overlap (bool, optional): Whether to return overlapping isochrones or non-overlapping ones. Defaults to True.
-
+        area_threshold (float, optional): Minimum area threshold to filter out small polygons within the isochrones. Defaults to 1e-6.
     Returns:
         gpd.GeoDataFrame: A GeoDataFrame containing the isochrones.
     """
@@ -74,6 +76,25 @@ def calculate_isochrones(
 
     isochrone = gpd.GeoDataFrame.from_features(r.json()["features"])
     isochrone.crs = crs
+
+    def filter_small_polygons(
+        geom: Union[MultiPolygon, Polygon, None], min_area: float
+    ) -> Union[MultiPolygon, Polygon, None]:
+        if isinstance(geom, MultiPolygon):
+            # Only filter out if there is more than one polygon
+            if len(geom.geoms) == 1:
+                return geom
+            filtered = [p for p in geom.geoms if p.area >= min_area]
+            if not filtered:
+                return None  # Or Polygon() for empty
+            return MultiPolygon(filtered)
+        elif isinstance(geom, Polygon):
+            return geom
+        return geom
+
+    isochrone["geometry"] = isochrone["geometry"].map(
+        lambda geom: filter_small_polygons(geom, area_threshold)
+    )
 
     if not overlap and len(cutoffSec) > 1:
         # Sort by time to ensure correct order for difference calculation

--- a/tests/test_isochrones.py
+++ b/tests/test_isochrones.py
@@ -1,0 +1,58 @@
+import unittest
+from shapely.geometry import Polygon, MultiPolygon
+from isochrones.isochrones import filter_small_polygons
+
+
+class TestFilterSmallPolygons(unittest.TestCase):
+    def setUp(self):
+        # Create helper geometries
+        # Area = 0.01
+        self.small_poly = Polygon([(0, 0), (0, 0.1), (0.1, 0.1), (0.1, 0), (0, 0)])
+        # Area = 100
+        self.large_poly = Polygon([(0, 0), (0, 10), (10, 10), (10, 0), (0, 0)])
+        self.threshold = 1.0
+
+    def test_multipolygons_filtering(self):
+        """MultiPolygons with small polygons are correctly filtered."""
+        # Create MultiPolygon with one large and one small polygon
+        geom = MultiPolygon([self.large_poly, self.small_poly])
+        result = filter_small_polygons(geom, self.threshold)
+
+        # Should return a MultiPolygon with only the large polygon
+        self.assertIsInstance(result, MultiPolygon)
+        self.assertEqual(len(result.geoms), 1)
+        self.assertEqual(result.geoms[0], self.large_poly)
+
+    def test_all_polygons_filtered(self):
+        """All polygons being filtered out results in an empty Polygon."""
+        # Create MultiPolygon with two small polygons
+        geom = MultiPolygon([self.small_poly, self.small_poly])
+        result = filter_small_polygons(geom, self.threshold)
+
+        # Should return an empty Polygon
+        self.assertIsInstance(result, Polygon)
+        self.assertTrue(result.is_empty)
+
+    def test_single_multipolygon_not_filtered(self):
+        """Single-polygon MultiPolygons are not filtered."""
+        # Even though it's small, it's the only one, so it should stay
+        geom = MultiPolygon([self.small_poly])
+        result = filter_small_polygons(geom, self.threshold)
+
+        self.assertEqual(geom, result)
+
+    def test_regular_polygon_unchanged(self):
+        """Regular Polygons pass through unchanged."""
+        # Regular polygons are returned as-is, regardless of size
+        result = filter_small_polygons(self.small_poly, self.threshold)
+        self.assertEqual(self.small_poly, result)
+
+    def test_none_input(self):
+        """None input results in an empty Polygon."""
+        result = filter_small_polygons(None, self.threshold)
+        self.assertIsInstance(result, Polygon)
+        self.assertTrue(result.is_empty)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pois.py
+++ b/tests/test_pois.py
@@ -1,23 +1,20 @@
 import os
 import sys
 import pytest
-
-# Ensure project root is on sys.path so the local package can be imported without installation
-PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-if PROJECT_ROOT not in sys.path:
-    sys.path.insert(0, PROJECT_ROOT)
-
 from isochrones import get_osm_features
 
 bbox = (6.13, 46.19, 6.15, 46.21)
 tags = {"amenity": ["school", "hospital"]}
-#tags = {"public_transport": True}
-#tags = {"shop": True}
+# tags = {"public_transport": True}
+# tags = {"shop": True}
 crs = "EPSG:4326"
 
+
 def test_get_osm_features_from_local_pbf():
-    osmData = os.path.join(os.path.dirname(__file__), "..", ".data", "geneva-greater-area-all.osm.pbf")
-    
+    osmData = os.path.join(
+        os.path.dirname(__file__), "..", ".data", "geneva-greater-area-all.osm.pbf"
+    )
+
     # Check osm data file exists
     if not os.path.exists(osmData):
         pytest.skip(f"Test OSM PBF data file is missing: {osmData}")
@@ -29,6 +26,7 @@ def test_get_osm_features_from_local_pbf():
         crs=crs,
     )
     print(gdf, file=sys.stdout)
+
 
 def test_get_osm_features_from_package_pbf():
     gdf = get_osm_features(
@@ -42,6 +40,7 @@ def test_get_osm_features_from_package_pbf():
     assert not gdf.empty
     # Assert length
     assert len(gdf) == 8
+
 
 # def test_get_osm_features_from_overpass():
 #     gdf = get_osm_features(


### PR DESCRIPTION
This PR fixes the issues with mutually exclusive isochrones in `calcule_isochrones`. It's adressed by adding a new optional float parameter, `area_threshold`, which defaults to 1e-6. This value may have to change in the future, to find a good tradeoff between removing small areas and reducing the quality of the isochrones

Fixes: #22

# Describe your changes

Please explain the purpose and scope of your contribution.

# Related GitHub issues and pull requests

- Closes: #22

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] Don't forget to link PR to issue if you are solving one.
