### PR TITLE
fix: update the filtering of stops

### DIFF
--- a/isochrones/pois.py
+++ b/isochrones/pois.py
@@ -73,11 +73,15 @@ def filter_routes_by_isochrone(
                 lambda x: any(route_id in routes_in_isochrone for route_id in x)
             )
         ]
+
+        # Collect all variant route IDs from the filtered route_masters
+        filtered_route_ids = set()
+        for variant_ids in filtered_routes["variant_route_ids"]:
+            filtered_route_ids.update(variant_ids)
     else:
         filtered_routes = routes[routes["osm_id"].isin(routes_in_isochrone)]
+        filtered_route_ids = set(filtered_routes["osm_id"])
 
-    # Repeat the process for the stops, only counting those that appear in the filtered routes
-    filtered_route_ids = set(filtered_routes["osm_id"])
     stops_in_filtered_routes = stops[
         stops["route_ids"].apply(
             lambda route_ids: any(

--- a/tests/test_transit_filtering.py
+++ b/tests/test_transit_filtering.py
@@ -347,10 +347,9 @@ def test_filter_routes_grouped_by_route_master(
 ):
     """Test filtering with routes grouped by route_master.
 
-    Note: When routes are grouped by route_master, the function returns the
-    route_master rows, but the stops are filtered based on whether their
-    route_ids match the route_master osm_id values, not the variant route IDs.
-    This means stops will be empty unless they reference the route_master IDs.
+    When routes are grouped by route_master, the function should:
+    1. Filter route_masters based on whether any variant routes have stops in the isochrone
+    2. Return stops that belong to any of the variant routes in the filtered route_masters
     """
     routes, stops = filter_routes_by_isochrone(
         mock_transit_routes_grouped,
@@ -370,13 +369,23 @@ def test_filter_routes_grouped_by_route_master(
     # Master 203 (tram routes 105, 106) should be included (105 has 2 stops)
     assert len(routes) >= 2, "Should find at least 2 route masters"
 
-    # Note: Stops will be empty because they reference variant route IDs (101-106)
-    # but the function looks for route_master IDs (201-203) when filtering stops.
-    # This is expected behavior - the stops dataframe needs to be pre-processed
-    # to reference route_master IDs if routes are grouped that way.
+    # Verify that stops are correctly filtered based on variant route IDs
+    # Stops should include those belonging to routes 101-106 (variants of included masters)
+    assert len(stops) > 0, "Should find stops belonging to variant routes"
+
+    # Verify specific stops are included:
+    # - Stops 1-3 belong to routes 101, 102 (variants of master 201)
+    # - Stops 4-6 belong to routes 103, 104 (variants of master 202)
+    # - Stops 7-8 belong to routes 105, 106 (variants of master 203)
+    stop_ids = set(stops["osm_id"].tolist())
+    expected_stops = {1, 2, 3, 4, 5, 6, 7, 8}  # All stops inside the isochrone
+    assert stop_ids == expected_stops, (
+        f"Expected stops {expected_stops}, got {stop_ids}"
+    )
+
     print(
         f"✓ test_filter_routes_grouped_by_route_master: Found {len(routes)} "
-        f"route masters (stops={len(stops)} as expected with ID mismatch)"
+        f"route masters, {len(stops)} stops"
     )
 
 


### PR DESCRIPTION
# Describe your changes

Before, the filtering of the stops for routes grouped be `route_master` was based on the OSM ID of the route master, not of the route variants. This PR fixes this and will include stops belonging to any of the route variants that are identified as having enough stops within the isochrone to be included.

## Before

<img width="440" height="800" alt="image" src="https://github.com/user-attachments/assets/fa199c23-26d8-45a6-9271-648825d6835d" />

## After

<img width="858" height="1561" alt="image" src="https://github.com/user-attachments/assets/e151ea49-3b15-4c1c-b0f9-1192500d7365" />


# Related GitHub issues and pull requests


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] Don't forget to link PR to issue if you are solving one.
