### PR TITLE
feat: add proximity-based filtering of routes

### DIFF
--- a/example.ipynb
+++ b/example.ipynb
@@ -33,6 +33,7 @@
     "from isochrones import (\n",
     "    calculate_isochrones,\n",
     "    filter_routes_by_isochrone,\n",
+    "    filter_routes_by_proximity,\n",
     ")\n",
     "\n",
     "load_dotenv()\n",
@@ -46,13 +47,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# # Oyonnax, France\n",
-    "# lat = 46.2575459498246\n",
-    "# lon = 5.6543942515264245\n",
+    "# Geneva, Switzerland\n",
+    "lat = 46.208471\n",
+    "lon = 6.135693\n",
     "\n",
-    "# Bourg-en-Bresse, France\n",
-    "lat = 46.205229187118256\n",
-    "lon = 5.22582674563499\n",
+    "# # # Oyonnax, France\n",
+    "# # lat = 46.2575459498246\n",
+    "# # lon = 5.6543942515264245\n",
+    "\n",
+    "# # Bourg-en-Bresse, France\n",
+    "# lat = 46.205229187118256\n",
+    "# lon = 5.22582674563499\n",
+    "\n",
+    "# # Miribel, France\n",
+    "# lat = 45.82637587832268\n",
+    "# lon = 4.957136103947748\n",
+    "\n",
+    "# # Meximieux, France\n",
+    "# lat = 45.90175746509154\n",
+    "# lon = 5.19321901351534\n",
     "bounding_box = (\n",
     "    lon - 0.3,\n",
     "    lat - 0.3,\n",
@@ -69,6 +82,16 @@
    "outputs": [],
    "source": [
     "bounding_box"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "159e3a9f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Test the OSM features"
    ]
   },
   {
@@ -90,7 +113,7 @@
     "    osm_pbf_path=\"isochrones/data/geneva-greater-area.osm.pbf\",\n",
     "    route_types=[\"train\", \"bus\", \"tram\", \"light_rail\", \"subway\", \"trolleybus\"],\n",
     "    include_stop_ids=True,\n",
-    "    group_by=\"route_master\",\n",
+    "    group_by=\"route\",\n",
     ")"
    ]
   },
@@ -102,31 +125,6 @@
    "outputs": [],
    "source": [
     "routes.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a196bed3",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ungrouped_routes = extract_all_transit_routes(\n",
-    "    osm_pbf_path=\"isochrones/data/geneva-greater-area.osm.pbf\",\n",
-    "    route_types=[\"train\", \"bus\", \"tram\", \"light_rail\", \"subway\", \"trolleybus\"],\n",
-    "    include_stop_ids=True,\n",
-    "    group_by=\"route\",\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "efe0b206",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ungrouped_routes"
    ]
   },
   {
@@ -145,11 +143,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c21771c6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(routes), len(stops)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "fd3a3da2",
    "metadata": {},
    "outputs": [],
    "source": [
-    "routes.head()"
+    "stops.head()"
    ]
   },
   {
@@ -252,13 +260,14 @@
     "plot_routes.to_crs(epsg=3857).plot(\n",
     "    ax=ax,\n",
     "    column=\"route_master_name\",\n",
-    "    legend=True,\n",
+    "    legend=False,\n",
     "    legend_kwds={\n",
     "        \"loc\": \"upper left\",\n",
     "        \"bbox_to_anchor\": (1.02, 1),\n",
     "        \"title\": \"Route master name\",\n",
     "        \"frameon\": True,\n",
     "    },\n",
+    "    zorder=2,\n",
     ")\n",
     "\n",
     "isochrones.to_crs(epsg=3857).plot(\n",
@@ -270,7 +279,7 @@
     "    alpha=0.5,\n",
     ")\n",
     "\n",
-    "stops.clip(bbox).to_crs(epsg=3857).plot(\n",
+    "filtered_stops.clip(bbox).to_crs(epsg=3857).plot(\n",
     "    ax=ax,\n",
     "    color=\"red\",\n",
     "    markersize=10,\n",
@@ -283,7 +292,82 @@
     "plt.title(\"Transit Routes in intersecting bounding box\")\n",
     "plt.xlabel(\"Longitude\")\n",
     "plt.ylabel(\"Latitude\")\n",
-    "# plt.tight_layout(rect=(0, 0, 0.75, 1))\n",
+    "# plt.xlim(681500, 683500)\n",
+    "# plt.ylim(5811500, 5813500)\n",
+    "plt.tight_layout(rect=(0, 0, 0.75, 1))\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da5dae58",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filtered_routes, filtered_stops = filter_routes_by_proximity(\n",
+    "    routes,\n",
+    "    stops,\n",
+    "    center_lat=lat,\n",
+    "    center_lon=lon,\n",
+    "    radius=500.0,\n",
+    "    min_stops=1,\n",
+    "    simplify=0.0001,\n",
+    "    isochrone=isochrones,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f93e69b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_routes = filtered_routes.clip(bbox).copy()\n",
+    "# plot_routes = filtered_routes.copy()\n",
+    "plot_routes[\"route_master_name\"] = plot_routes[\"route_master_name\"].fillna(\"Unknown\")\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(14, 10))\n",
+    "\n",
+    "plot_routes.to_crs(epsg=3857).plot(\n",
+    "    ax=ax,\n",
+    "    column=\"route_master_name\",\n",
+    "    legend=False,\n",
+    "    legend_kwds={\n",
+    "        \"loc\": \"upper left\",\n",
+    "        \"bbox_to_anchor\": (1.02, 1),\n",
+    "        \"title\": \"Route master name\",\n",
+    "        \"frameon\": True,\n",
+    "    },\n",
+    "    zorder=2,\n",
+    ")\n",
+    "\n",
+    "isochrones.to_crs(epsg=3857).plot(\n",
+    "    ax=ax,\n",
+    "    color=\"lightblue\",\n",
+    "    edgecolor=\"blue\",\n",
+    "    linewidth=2,\n",
+    "    label=\"30 min isochrone\",\n",
+    "    alpha=0.5,\n",
+    ")\n",
+    "\n",
+    "filtered_stops.clip(bbox).to_crs(epsg=3857).plot(\n",
+    "    ax=ax,\n",
+    "    color=\"red\",\n",
+    "    markersize=10,\n",
+    "    label=\"Transit Stops\",\n",
+    "    zorder=3,\n",
+    "    alpha=0.7,\n",
+    ")\n",
+    "\n",
+    "ctx.add_basemap(ax, source=ctx.providers.OpenStreetMap.CH, zoom=12)\n",
+    "plt.title(\"Transit Routes in intersecting bounding box\")\n",
+    "plt.xlabel(\"Longitude\")\n",
+    "plt.ylabel(\"Latitude\")\n",
+    "# plt.xlim(681500, 683500)\n",
+    "# plt.ylim(5811500, 5813500)\n",
+    "plt.tight_layout(rect=(0, 0, 0.75, 1))\n",
     "plt.show()"
    ]
   }

--- a/isochrones/__init__.py
+++ b/isochrones/__init__.py
@@ -6,6 +6,7 @@ from .isochrones import (
 from .pois import (
     count_route_stops_in_isochrones,
     filter_routes_by_isochrone,
+    filter_routes_by_proximity,
     get_osm_files,
     group_stops_by_name,
 )
@@ -14,6 +15,7 @@ __all__ = [
     "calculate_isochrones",
     "count_route_stops_in_isochrones",
     "filter_routes_by_isochrone",
+    "filter_routes_by_proximity",
     "get_available_modes",
     "get_osm_files",
     "group_stops_by_name",

--- a/isochrones/pois.py
+++ b/isochrones/pois.py
@@ -115,6 +115,7 @@ def filter_routes_by_proximity(
     radius: float = 500.0,
     min_stops: int = 1,
     simplify: Optional[float] = None,
+    isochrone: Optional[gpd.GeoDataFrame] = None,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame]:
     """
     Filter transit routes by proximity to a center point using circular radius search.
@@ -136,6 +137,8 @@ def filter_routes_by_proximity(
         simplify (Optional[float], optional): If provided, simplifies route geometries using
             this tolerance value (in CRS units, typically degrees for EPSG:4326).
             Default: None (no simplification).
+        isochrone (Optional[gpd.GeoDataFrame], optional): Pre-computed isochrone polygon(s)
+            for pre-filtering stops before distance calculation. Default: None.
 
     Returns:
         tuple[gpd.GeoDataFrame, gpd.GeoDataFrame]: A tuple containing:
@@ -146,7 +149,7 @@ def filter_routes_by_proximity(
         ValueError: If required columns are missing from input GeoDataFrames.
 
     Examples:
-        >>> # Filter routes within 500m of a location
+        >>> # Basic usage (processes all stops - slower for large datasets)
         >>> routes, stops = filter_routes_by_proximity(
         ...     routes=all_routes,
         ...     stops=all_stops,
@@ -155,14 +158,20 @@ def filter_routes_by_proximity(
         ... )
         >>> print(f"Found {len(routes)} routes within 500m")
 
-        >>> # Larger radius with higher threshold
+        >>> # Optimized usage with isochrone
+        >>> # First calculate isochrone for the area
+        >>> isochrone = calculate_isochrones(
+        ...     lat=46.2044, lon=6.1432, cutoffSec=[600],
+        ...     date_time=datetime.now(), mode="WALK", otp_url="..."
+        ... )
+        >>>
+        >>> # Then use it to accelerate proximity filtering
         >>> routes, stops = filter_routes_by_proximity(
         ...     routes=all_routes,
         ...     stops=all_stops,
         ...     center_lat=46.2044,
         ...     center_lon=6.1432,
-        ...     radius=1000.0,  # 1km radius
-        ...     min_stops=3,     # Need 3+ stops within radius
+        ...     isochrone=isochrone,
         ... )
 
         >>> # With geometry simplification
@@ -172,92 +181,110 @@ def filter_routes_by_proximity(
         ...     center_lat=46.2044,
         ...     center_lon=6.1432,
         ...     simplify=0.0001,  # Simplify geometry (~11m tolerance at equator)
+        ...     isochrone=isochrone,
         ... )
-
-    Notes:
-        - The function converts to EPSG:3857 (Web Mercator) internally for accurate
-          metric distance calculations, then returns results in the input CRS.
-        - All route types (train, bus, tram, etc.) use the same min_stops threshold,
-          unlike filter_routes_by_isochrone which treats trains differently.
-        - The returned stops include ALL stops from the filtered routes, not just
-          those within the radius. This ensures complete route information.
-        - Supports both grouped (route_master) and ungrouped routes via automatic
-          detection of the 'variant_route_ids' column.
 
     See Also:
         - filter_routes_by_isochrone(): Filter routes by isochrone polygon coverage
         - count_route_stops_in_isochrones(): Count stops per route within polygons
+        - calculate_isochrones(): Create isochrone polygons for your area
     """
     if stops.empty or routes.empty:
         return routes.iloc[0:0].copy(), stops.iloc[0:0].copy()
 
-    # Store original CRS to return results in same CRS as input
-    original_routes_crs = routes.crs
-    original_stops_crs = stops.crs
+    if isochrone is not None:
+        # Ensure same CRS for clipping
+        if stops.crs != isochrone.crs:
+            stops_to_clip = stops.to_crs(isochrone.crs)
+        else:
+            stops_to_clip = stops
 
-    # Create center point in EPSG:4326
+        # Spatial join to clip stops to isochrone boundary
+        stops_clipped = gpd.sjoin(
+            stops_to_clip, isochrone, how="inner", predicate="within"
+        )
+
+        # Remove join artifacts (columns ending with _right, index_right, etc.)
+        cols_to_drop = [
+            col for col in stops_clipped.columns if col.endswith("_right")
+        ] + ["index_right"]
+        stops_clipped = stops_clipped.drop(columns=cols_to_drop, errors="ignore")
+
+        # Use clipped stops for distance calculation (much smaller dataset!)
+        stops_for_distance = stops_clipped
+
+        # If no stops in isochrone, return empty results
+        if stops_for_distance.empty:
+            return routes.iloc[0:0].copy(), stops.iloc[0:0].copy()
+    else:
+        # No isochrone provided - process all stops (slower)
+        stops_for_distance = stops
+
+    # Check if input is already projected (metric)
+    try:
+        if stops_for_distance.crs.is_projected:
+            working_crs = stops_for_distance.crs
+        else:
+            working_crs = "EPSG:3857"
+    except AttributeError:
+        # Fallback for older geopandas versions without is_projected
+        working_crs = "EPSG:3857"
+
     center_point = Point(center_lon, center_lat)
     center_gdf = gpd.GeoDataFrame({"id": [1]}, geometry=[center_point], crs="EPSG:4326")
-
-    # Convert to EPSG:3857 (Web Mercator) for accurate metric distance calculations
-    center_gdf = center_gdf.to_crs("EPSG:3857")
-    stops_metric = stops.to_crs("EPSG:3857")
-    routes_metric = routes.to_crs("EPSG:3857")
+    center_gdf = center_gdf.to_crs(working_crs)
 
     # Create circular buffer around center point (radius in meters)
     buffer_polygon = center_gdf.geometry.iloc[0].buffer(radius)
     buffer_gdf = gpd.GeoDataFrame(
-        {"id": [1]}, geometry=[buffer_polygon], crs="EPSG:3857"
+        {"id": [1]}, geometry=[buffer_polygon], crs=working_crs
     )
 
-    # Use the existing count_route_stops_in_isochrones helper
-    # (it works with any polygon, not just isochrones)
+    if stops_for_distance.crs != working_crs:
+        stops_metric = stops_for_distance.to_crs(working_crs)
+    else:
+        stops_metric = stops_for_distance
+
     stops_per_route = count_route_stops_in_isochrones(stops_metric, buffer_gdf)
 
-    # Filter routes with at least min_stops within radius
-    # Unlike filter_routes_by_isochrone, all transit modes use the same threshold
     routes_in_radius = stops_per_route[stops_per_route["stop_count"] >= min_stops][
         "route_ids"
     ].tolist()
     routes_in_radius_set = set(routes_in_radius)
 
-    # Check whether the data frame was grouped by route_master or route
-    grouped_by_route_master = False
-    if "variant_route_ids" in routes_metric.columns:
-        grouped_by_route_master = True
+    # Check whether routes are grouped by route_master
+    grouped_by_route_master = "variant_route_ids" in routes.columns
 
+    # Filter routes (work in ORIGINAL CRS - no conversion needed!)
     if grouped_by_route_master:
-        filtered_routes = routes_metric[
-            routes_metric["variant_route_ids"].apply(
+        filtered_routes = routes[
+            routes["variant_route_ids"].apply(
                 lambda x: any(route_id in routes_in_radius_set for route_id in x)
             )
         ]
-    else:
-        filtered_routes = routes_metric[
-            routes_metric["osm_id"].isin(routes_in_radius_set)
-        ]
 
-    # Get all stops that belong to the filtered routes
-    filtered_route_ids = set(filtered_routes["osm_id"])
-    stops_in_filtered_routes = stops_metric[
-        stops_metric["route_ids"].apply(
+        # Collect all variant route IDs from filtered route_masters
+        filtered_route_ids = set()
+        for variant_ids in filtered_routes["variant_route_ids"]:
+            filtered_route_ids.update(variant_ids)
+    else:
+        filtered_routes = routes[routes["osm_id"].isin(routes_in_radius_set)]
+        filtered_route_ids = set(filtered_routes["osm_id"])
+
+    stops_in_filtered_routes = stops[
+        stops["route_ids"].apply(
             lambda route_ids: any(
                 route_id in filtered_route_ids for route_id in route_ids
             )
         )
     ]
 
-    # Apply geometry simplification if requested
     if simplify is not None:
         # Create a copy to avoid SettingWithCopyWarning
         filtered_routes = filtered_routes.copy()
         filtered_routes["geometry"] = filtered_routes.geometry.simplify(
             tolerance=simplify
         )
-
-    # Convert back to original CRS
-    filtered_routes = filtered_routes.to_crs(original_routes_crs)
-    stops_in_filtered_routes = stops_in_filtered_routes.to_crs(original_stops_crs)
 
     return filtered_routes, stops_in_filtered_routes
 

--- a/isochrones/pois.py
+++ b/isochrones/pois.py
@@ -1,6 +1,8 @@
 import geopandas as gpd
 import pandas as pd
 from importlib.resources import files
+from typing import Optional
+from shapely.geometry import Point
 
 
 def get_osm_files():
@@ -19,6 +21,7 @@ def filter_routes_by_isochrone(
     stops: gpd.GeoDataFrame,
     isochrone: gpd.GeoDataFrame,
     min_stops_bus_tram: int = 2,
+    simplify: Optional[float] = None,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame]:
     """
     Filter transit routes by isochrone coverage using pre-extracted data.
@@ -31,6 +34,9 @@ def filter_routes_by_isochrone(
         isochrone (gpd.GeoDataFrame): Isochrone polygon(s) to filter by (from calculate_isochrones()).
         min_stops_bus_tram (int, optional): Minimum number of stops required for bus/tram routes
             to be included. Trains are always included regardless. Default: 2.
+        simplify (Optional[float], optional): If provided, simplifies route geometries using
+            this tolerance value (in CRS units, typically degrees for EPSG:4326).
+            Default: None (no simplification).
 
     Returns:
         tuple[gpd.GeoDataFrame, gpd.GeoDataFrame]: A tuple containing the filtered routes and the stops within those routes.
@@ -89,6 +95,169 @@ def filter_routes_by_isochrone(
             )
         )
     ]
+
+    # Apply geometry simplification if requested
+    if simplify is not None:
+        # Create a copy to avoid SettingWithCopyWarning
+        filtered_routes = filtered_routes.copy()
+        filtered_routes["geometry"] = filtered_routes.geometry.simplify(
+            tolerance=simplify
+        )
+
+    return filtered_routes, stops_in_filtered_routes
+
+
+def filter_routes_by_proximity(
+    routes: gpd.GeoDataFrame,
+    stops: gpd.GeoDataFrame,
+    center_lat: float,
+    center_lon: float,
+    radius: float = 500.0,
+    min_stops: int = 1,
+    simplify: Optional[float] = None,
+) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame]:
+    """
+    Filter transit routes by proximity to a center point using circular radius search.
+
+    This function finds all routes that have at least min_stops within a circular
+    radius around a center point. Unlike filter_routes_by_isochrone which uses
+    irregular polygon boundaries, this uses simple distance-based filtering.
+
+    Args:
+        routes (gpd.GeoDataFrame): Pre-extracted transit routes. Must have columns: osm_id, route, ref, network,
+            from, to, geometry.
+        stops (gpd.GeoDataFrame): Pre-extracted transit stops (from extract_all_transit_stops()
+            or loaded from GeoParquet). Must have columns: osm_id, route_ids, transit_mode, geometry.
+        center_lat (float): Latitude of the center point (in EPSG:4326).
+        center_lon (float): Longitude of the center point (in EPSG:4326).
+        radius (float, optional): Search radius in meters. Default: 500.0.
+        min_stops (int, optional): Minimum number of stops required within the radius
+            for a route to be included. Applies to all transit modes equally. Default: 1.
+        simplify (Optional[float], optional): If provided, simplifies route geometries using
+            this tolerance value (in CRS units, typically degrees for EPSG:4326).
+            Default: None (no simplification).
+
+    Returns:
+        tuple[gpd.GeoDataFrame, gpd.GeoDataFrame]: A tuple containing:
+            - Filtered routes with at least min_stops within radius
+            - All stops belonging to those filtered routes (not just stops within radius)
+
+    Raises:
+        ValueError: If required columns are missing from input GeoDataFrames.
+
+    Examples:
+        >>> # Filter routes within 500m of a location
+        >>> routes, stops = filter_routes_by_proximity(
+        ...     routes=all_routes,
+        ...     stops=all_stops,
+        ...     center_lat=46.2044,
+        ...     center_lon=6.1432,
+        ... )
+        >>> print(f"Found {len(routes)} routes within 500m")
+
+        >>> # Larger radius with higher threshold
+        >>> routes, stops = filter_routes_by_proximity(
+        ...     routes=all_routes,
+        ...     stops=all_stops,
+        ...     center_lat=46.2044,
+        ...     center_lon=6.1432,
+        ...     radius=1000.0,  # 1km radius
+        ...     min_stops=3,     # Need 3+ stops within radius
+        ... )
+
+        >>> # With geometry simplification
+        >>> routes, stops = filter_routes_by_proximity(
+        ...     routes=all_routes,
+        ...     stops=all_stops,
+        ...     center_lat=46.2044,
+        ...     center_lon=6.1432,
+        ...     simplify=0.0001,  # Simplify geometry (~11m tolerance at equator)
+        ... )
+
+    Notes:
+        - The function converts to EPSG:3857 (Web Mercator) internally for accurate
+          metric distance calculations, then returns results in the input CRS.
+        - All route types (train, bus, tram, etc.) use the same min_stops threshold,
+          unlike filter_routes_by_isochrone which treats trains differently.
+        - The returned stops include ALL stops from the filtered routes, not just
+          those within the radius. This ensures complete route information.
+        - Supports both grouped (route_master) and ungrouped routes via automatic
+          detection of the 'variant_route_ids' column.
+
+    See Also:
+        - filter_routes_by_isochrone(): Filter routes by isochrone polygon coverage
+        - count_route_stops_in_isochrones(): Count stops per route within polygons
+    """
+    if stops.empty or routes.empty:
+        return routes.iloc[0:0].copy(), stops.iloc[0:0].copy()
+
+    # Store original CRS to return results in same CRS as input
+    original_routes_crs = routes.crs
+    original_stops_crs = stops.crs
+
+    # Create center point in EPSG:4326
+    center_point = Point(center_lon, center_lat)
+    center_gdf = gpd.GeoDataFrame({"id": [1]}, geometry=[center_point], crs="EPSG:4326")
+
+    # Convert to EPSG:3857 (Web Mercator) for accurate metric distance calculations
+    center_gdf = center_gdf.to_crs("EPSG:3857")
+    stops_metric = stops.to_crs("EPSG:3857")
+    routes_metric = routes.to_crs("EPSG:3857")
+
+    # Create circular buffer around center point (radius in meters)
+    buffer_polygon = center_gdf.geometry.iloc[0].buffer(radius)
+    buffer_gdf = gpd.GeoDataFrame(
+        {"id": [1]}, geometry=[buffer_polygon], crs="EPSG:3857"
+    )
+
+    # Use the existing count_route_stops_in_isochrones helper
+    # (it works with any polygon, not just isochrones)
+    stops_per_route = count_route_stops_in_isochrones(stops_metric, buffer_gdf)
+
+    # Filter routes with at least min_stops within radius
+    # Unlike filter_routes_by_isochrone, all transit modes use the same threshold
+    routes_in_radius = stops_per_route[stops_per_route["stop_count"] >= min_stops][
+        "route_ids"
+    ].tolist()
+    routes_in_radius_set = set(routes_in_radius)
+
+    # Check whether the data frame was grouped by route_master or route
+    grouped_by_route_master = False
+    if "variant_route_ids" in routes_metric.columns:
+        grouped_by_route_master = True
+
+    if grouped_by_route_master:
+        filtered_routes = routes_metric[
+            routes_metric["variant_route_ids"].apply(
+                lambda x: any(route_id in routes_in_radius_set for route_id in x)
+            )
+        ]
+    else:
+        filtered_routes = routes_metric[
+            routes_metric["osm_id"].isin(routes_in_radius_set)
+        ]
+
+    # Get all stops that belong to the filtered routes
+    filtered_route_ids = set(filtered_routes["osm_id"])
+    stops_in_filtered_routes = stops_metric[
+        stops_metric["route_ids"].apply(
+            lambda route_ids: any(
+                route_id in filtered_route_ids for route_id in route_ids
+            )
+        )
+    ]
+
+    # Apply geometry simplification if requested
+    if simplify is not None:
+        # Create a copy to avoid SettingWithCopyWarning
+        filtered_routes = filtered_routes.copy()
+        filtered_routes["geometry"] = filtered_routes.geometry.simplify(
+            tolerance=simplify
+        )
+
+    # Convert back to original CRS
+    filtered_routes = filtered_routes.to_crs(original_routes_crs)
+    stops_in_filtered_routes = stops_in_filtered_routes.to_crs(original_stops_crs)
 
     return filtered_routes, stops_in_filtered_routes
 

--- a/tests/test_transit_filtering.py
+++ b/tests/test_transit_filtering.py
@@ -807,6 +807,175 @@ def test_filter_routes_by_proximity_returns_all_stops(
     )
 
 
+def test_filter_routes_by_proximity_with_isochrone(
+    mock_transit_routes, mock_transit_stops, mock_isochrone_small
+):
+    """Test proximity filtering with isochrone pre-clipping optimization."""
+    routes, stops = filter_routes_by_proximity(
+        mock_transit_routes,
+        mock_transit_stops,
+        center_lat=46.2035,
+        center_lon=6.1435,
+        radius=500.0,
+        isochrone=mock_isochrone_small,
+    )
+
+    # Should find routes within the isochrone
+    assert len(routes) > 0, "Should find routes with isochrone"
+    assert len(stops) > 0, "Should find stops with isochrone"
+
+    # Results should be same or subset of without isochrone
+    # (because isochrone pre-filters the dataset)
+
+    print(
+        f"✓ test_filter_routes_by_proximity_with_isochrone: Found {len(routes)} routes, "
+        f"{len(stops)} stops with isochrone"
+    )
+
+
+def test_filter_routes_by_proximity_isochrone_empty():
+    """Test that empty results are returned when isochrone doesn't overlap stops."""
+    # Create stops far from isochrone
+    stops = gpd.GeoDataFrame(
+        {
+            "osm_id": [1, 2],
+            "route_ids": [[101], [101]],
+            "transit_mode": ["bus", "bus"],
+            "geometry": [
+                Point(7.0, 47.0),  # Far from isochrone
+                Point(7.1, 47.1),
+            ],
+        },
+        crs="EPSG:4326",
+    )
+
+    routes = gpd.GeoDataFrame(
+        {
+            "osm_id": [101],
+            "route": ["bus"],
+            "ref": ["1"],
+            "network": ["TPG"],
+            "from": ["A"],
+            "to": ["B"],
+            "geometry": [LineString([(7.0, 47.0), (7.1, 47.1)])],
+        },
+        crs="EPSG:4326",
+    )
+
+    # Isochrone in Geneva (far from stops)
+    isochrone = gpd.GeoDataFrame(
+        {
+            "time": [600],
+            "geometry": [
+                Polygon(
+                    [
+                        (6.139, 46.199),
+                        (6.148, 46.199),
+                        (6.148, 46.208),
+                        (6.139, 46.208),
+                        (6.139, 46.199),
+                    ]
+                )
+            ],
+        },
+        crs="EPSG:4326",
+    )
+
+    # Filter with isochrone that doesn't overlap
+    filtered_routes, filtered_stops = filter_routes_by_proximity(
+        routes,
+        stops,
+        center_lat=46.2035,
+        center_lon=6.1435,
+        radius=500.0,
+        isochrone=isochrone,
+    )
+
+    # Should return empty results (no stops in isochrone)
+    assert len(filtered_routes) == 0, (
+        "Should return no routes when isochrone doesn't overlap"
+    )
+    assert len(filtered_stops) == 0, (
+        "Should return no stops when isochrone doesn't overlap"
+    )
+
+    print("✓ test_filter_routes_by_proximity_isochrone_empty: Empty isochrone handled")
+
+
+def test_filter_routes_by_proximity_isochrone_crs_mismatch(
+    mock_transit_routes, mock_transit_stops, mock_isochrone_small
+):
+    """Test isochrone clipping with CRS mismatch."""
+    # Convert stops to EPSG:3857
+    stops_3857 = mock_transit_stops.to_crs("EPSG:3857")
+
+    # Isochrone stays in EPSG:4326
+    routes, stops = filter_routes_by_proximity(
+        mock_transit_routes,
+        stops_3857,
+        center_lat=46.2035,
+        center_lon=6.1435,
+        radius=500.0,
+        isochrone=mock_isochrone_small,
+    )
+
+    # Should handle CRS mismatch gracefully
+    assert routes.crs == mock_transit_routes.crs, "Routes should be in original CRS"
+    assert stops.crs == stops_3857.crs, "Stops should be in original CRS"
+    assert len(routes) > 0, "Should find routes despite CRS mismatch"
+
+    print(
+        "✓ test_filter_routes_by_proximity_isochrone_crs_mismatch: CRS mismatch handled"
+    )
+
+
+def test_filter_routes_by_proximity_none_isochrone(
+    mock_transit_routes, mock_transit_stops
+):
+    """Test that isochrone=None works (backward compatibility)."""
+    routes, stops = filter_routes_by_proximity(
+        mock_transit_routes,
+        mock_transit_stops,
+        center_lat=46.2035,
+        center_lon=6.1435,
+        isochrone=None,  # Explicit None
+    )
+
+    # Should work without isochrone
+    assert len(routes) > 0, "Should work with isochrone=None"
+    assert len(stops) > 0, "Should work with isochrone=None"
+
+    print(
+        "✓ test_filter_routes_by_proximity_none_isochrone: Backward compatibility maintained"
+    )
+
+
+def test_filter_routes_by_proximity_isochrone_grouped_routes(
+    mock_transit_routes_grouped, mock_transit_stops, mock_isochrone_small
+):
+    """Test isochrone optimization with grouped routes (route_master)."""
+    routes, stops = filter_routes_by_proximity(
+        mock_transit_routes_grouped,
+        mock_transit_stops,
+        center_lat=46.2035,
+        center_lon=6.1435,
+        radius=500.0,
+        min_stops=1,
+        isochrone=mock_isochrone_small,
+    )
+
+    # Should find route masters
+    assert len(routes) > 0, "Should find route masters with isochrone"
+
+    # Verify variant_route_ids column exists
+    assert "variant_route_ids" in routes.columns
+
+    print(
+        f"✓ test_filter_routes_by_proximity_isochrone_grouped_routes: Found {len(routes)} "
+        f"route masters with isochrone"
+    )
+
+
 # ============================================================================
 # Geometry Simplification Tests
 # ============================================================================

--- a/tests/test_transit_filtering.py
+++ b/tests/test_transit_filtering.py
@@ -10,7 +10,7 @@ import pandas as pd
 import pytest
 from shapely.geometry import LineString, Point, Polygon
 
-from isochrones import filter_routes_by_isochrone
+from isochrones import filter_routes_by_isochrone, filter_routes_by_proximity
 from isochrones.pois import count_route_stops_in_isochrones
 
 
@@ -513,6 +513,421 @@ def test_count_route_stops_edge_cases():
         count_route_stops_in_isochrones(bad_stops, isochrone)
 
     print("✓ test_count_route_stops_edge_cases: Edge cases handled correctly")
+
+
+# ============================================================================
+# Proximity Filtering Tests
+# ============================================================================
+
+
+def test_filter_routes_by_proximity_basic(mock_transit_routes, mock_transit_stops):
+    """Test basic proximity filtering with default 500m radius."""
+    # Use center point near the mock stops (6.140-6.147, 46.200-46.207)
+    routes, stops = filter_routes_by_proximity(
+        mock_transit_routes,
+        mock_transit_stops,
+        center_lat=46.2035,
+        center_lon=6.1435,
+        radius=500.0,  # 500m radius
+    )
+
+    # Check result types
+    assert isinstance(routes, gpd.GeoDataFrame)
+    assert isinstance(stops, gpd.GeoDataFrame)
+
+    # Should find some routes
+    assert len(routes) > 0, "Should find routes within 500m"
+    assert len(stops) > 0, "Should find stops within filtered routes"
+
+    # Results should be subset of input
+    assert len(routes) <= len(mock_transit_routes)
+    assert len(stops) <= len(mock_transit_stops)
+
+    print(
+        f"✓ test_filter_routes_by_proximity_basic: Found {len(routes)} routes, {len(stops)} stops"
+    )
+
+
+def test_filter_routes_by_proximity_radius_threshold(
+    mock_transit_routes, mock_transit_stops
+):
+    """Test different radius thresholds."""
+    center_lat, center_lon = 46.2035, 6.1435
+
+    # Small radius - should find fewer routes
+    routes_small, _ = filter_routes_by_proximity(
+        mock_transit_routes,
+        mock_transit_stops,
+        center_lat=center_lat,
+        center_lon=center_lon,
+        radius=100.0,  # 100m
+    )
+
+    # Large radius - should find more routes
+    routes_large, _ = filter_routes_by_proximity(
+        mock_transit_routes,
+        mock_transit_stops,
+        center_lat=center_lat,
+        center_lon=center_lon,
+        radius=2000.0,  # 2km
+    )
+
+    # Large radius should find more or equal routes
+    assert len(routes_large) >= len(routes_small), (
+        "Larger radius should find more or equal routes"
+    )
+
+    print(
+        f"✓ test_filter_routes_by_proximity_radius_threshold: Small={len(routes_small)}, "
+        f"Large={len(routes_large)} routes"
+    )
+
+
+def test_filter_routes_by_proximity_min_stops_threshold(
+    mock_transit_routes, mock_transit_stops
+):
+    """Test different min_stops thresholds."""
+    center_lat, center_lon = 46.2035, 6.1435
+
+    # Lenient filter (min_stops=1)
+    routes_lenient, _ = filter_routes_by_proximity(
+        mock_transit_routes,
+        mock_transit_stops,
+        center_lat=center_lat,
+        center_lon=center_lon,
+        radius=500.0,
+        min_stops=1,
+    )
+
+    # Strict filter (min_stops=3)
+    routes_strict, _ = filter_routes_by_proximity(
+        mock_transit_routes,
+        mock_transit_stops,
+        center_lat=center_lat,
+        center_lon=center_lon,
+        radius=500.0,
+        min_stops=3,
+    )
+
+    # Strict should return fewer or equal routes
+    assert len(routes_strict) <= len(routes_lenient), (
+        "Stricter min_stops should return fewer or equal routes"
+    )
+
+    print(
+        f"✓ test_filter_routes_by_proximity_min_stops_threshold: Lenient={len(routes_lenient)}, "
+        f"Strict={len(routes_strict)} routes"
+    )
+
+
+def test_filter_routes_by_proximity_empty_inputs():
+    """Test that empty inputs are handled gracefully."""
+    empty_routes = gpd.GeoDataFrame(
+        columns=["osm_id", "route", "geometry"], crs="EPSG:4326"
+    )
+    empty_stops = gpd.GeoDataFrame(
+        columns=["osm_id", "route_ids", "transit_mode", "geometry"], crs="EPSG:4326"
+    )
+
+    routes, stops = filter_routes_by_proximity(
+        empty_routes,
+        empty_stops,
+        center_lat=46.2044,
+        center_lon=6.1432,
+    )
+
+    assert isinstance(routes, gpd.GeoDataFrame)
+    assert isinstance(stops, gpd.GeoDataFrame)
+    assert routes.empty
+    assert stops.empty
+
+    print(
+        "✓ test_filter_routes_by_proximity_empty_inputs: Empty inputs handled correctly"
+    )
+
+
+def test_filter_routes_by_proximity_no_matches(mock_transit_routes, mock_transit_stops):
+    """Test when no routes are within radius."""
+    # Use a center point far from all stops
+    routes, stops = filter_routes_by_proximity(
+        mock_transit_routes,
+        mock_transit_stops,
+        center_lat=47.5000,  # Far from test data
+        center_lon=7.5000,
+        radius=500.0,
+    )
+
+    assert isinstance(routes, gpd.GeoDataFrame)
+    assert isinstance(stops, gpd.GeoDataFrame)
+    assert len(routes) == 0
+    assert len(stops) == 0
+
+    print("✓ test_filter_routes_by_proximity_no_matches: No matches handled correctly")
+
+
+def test_filter_routes_by_proximity_crs_handling(
+    mock_transit_routes, mock_transit_stops
+):
+    """Test that CRS conversion is handled correctly."""
+    # Convert to Web Mercator (EPSG:3857)
+    routes_3857 = mock_transit_routes.to_crs("EPSG:3857")
+    stops_3857 = mock_transit_stops.to_crs("EPSG:3857")
+
+    # Center point is provided in EPSG:4326 (always)
+    routes, stops = filter_routes_by_proximity(
+        routes_3857,
+        stops_3857,
+        center_lat=46.2035,
+        center_lon=6.1435,
+        radius=500.0,
+    )
+
+    # Results should be in the original input CRS (EPSG:3857)
+    assert routes.crs == routes_3857.crs
+    assert stops.crs == stops_3857.crs
+
+    # Should still find results despite different input CRS
+    assert len(routes) > 0, "Should find routes despite CRS mismatch"
+
+    print(
+        "✓ test_filter_routes_by_proximity_crs_handling: CRS conversion handled correctly"
+    )
+
+
+def test_filter_routes_by_proximity_grouped_routes(
+    mock_transit_routes_grouped, mock_transit_stops
+):
+    """Test proximity filtering with grouped routes (route_master)."""
+    routes, stops = filter_routes_by_proximity(
+        mock_transit_routes_grouped,
+        mock_transit_stops,
+        center_lat=46.2035,
+        center_lon=6.1435,
+        radius=500.0,
+        min_stops=1,
+    )
+
+    # Should find route masters
+    assert len(routes) > 0, "Should find route masters within radius"
+
+    # Verify variant_route_ids column exists
+    assert "variant_route_ids" in routes.columns
+
+    print(
+        f"✓ test_filter_routes_by_proximity_grouped_routes: Found {len(routes)} "
+        f"route masters (stops={len(stops)})"
+    )
+
+
+def test_filter_routes_by_proximity_all_modes_equal():
+    """Test that all transit modes use the same min_stops threshold."""
+    # Create stops with different modes at the same location
+    stops = gpd.GeoDataFrame(
+        {
+            "osm_id": [1, 2, 3],
+            "route_ids": [[101], [102], [103]],
+            "transit_mode": ["train", "bus", "tram"],
+            "geometry": [
+                Point(6.140, 46.200),
+                Point(6.141, 46.201),
+                Point(6.142, 46.202),
+            ],
+        },
+        crs="EPSG:4326",
+    )
+
+    routes = gpd.GeoDataFrame(
+        {
+            "osm_id": [101, 102, 103],
+            "route": ["train", "bus", "tram"],
+            "ref": ["T1", "1", "12"],
+            "network": ["TPG"] * 3,
+            "from": ["Station A"] * 3,
+            "to": ["Station B"] * 3,
+            "geometry": [
+                LineString([(6.140, 46.200), (6.150, 46.210)]),
+                LineString([(6.141, 46.201), (6.151, 46.211)]),
+                LineString([(6.142, 46.202), (6.152, 46.212)]),
+            ],
+        },
+        crs="EPSG:4326",
+    )
+
+    # Filter with min_stops=1 - should include all routes
+    routes_filtered, _ = filter_routes_by_proximity(
+        routes,
+        stops,
+        center_lat=46.2005,
+        center_lon=6.1415,
+        radius=500.0,
+        min_stops=1,
+    )
+
+    # All route types should be included (each has 1 stop)
+    assert len(routes_filtered) == 3, "All routes should be included with min_stops=1"
+
+    print(
+        "✓ test_filter_routes_by_proximity_all_modes_equal: All modes treated equally"
+    )
+
+
+def test_filter_routes_by_proximity_returns_all_stops(
+    mock_transit_routes, mock_transit_stops
+):
+    """Test that returned stops include ALL stops from filtered routes, not just those in radius."""
+    # Filter with a specific location
+    routes, stops = filter_routes_by_proximity(
+        mock_transit_routes,
+        mock_transit_stops,
+        center_lat=46.200,
+        center_lon=6.140,
+        radius=300.0,  # Small radius
+        min_stops=1,
+    )
+
+    # If we found routes, verify that ALL stops from those routes are returned
+    if len(routes) > 0:
+        route_ids = set(routes["osm_id"])
+
+        # Get all stops that reference these routes
+        expected_stops = mock_transit_stops[
+            mock_transit_stops["route_ids"].apply(
+                lambda rids: any(rid in route_ids for rid in rids)
+            )
+        ]
+
+        # The returned stops should match all stops from filtered routes
+        # (not just stops within the radius)
+        assert len(stops) == len(expected_stops), (
+            "Should return ALL stops from filtered routes, not just those in radius"
+        )
+
+    print(
+        "✓ test_filter_routes_by_proximity_returns_all_stops: All route stops returned"
+    )
+
+
+# ============================================================================
+# Geometry Simplification Tests
+# ============================================================================
+
+
+def test_filter_routes_by_isochrone_simplify_none(
+    mock_transit_routes, mock_transit_stops, mock_isochrone_small
+):
+    """Test that simplify=None (default) doesn't change geometry."""
+    routes_no_simplify, _ = filter_routes_by_isochrone(
+        mock_transit_routes,
+        mock_transit_stops,
+        mock_isochrone_small,
+    )
+
+    routes_explicit_none, _ = filter_routes_by_isochrone(
+        mock_transit_routes,
+        mock_transit_stops,
+        mock_isochrone_small,
+        simplify=None,
+    )
+
+    # Results should be identical
+    assert len(routes_no_simplify) == len(routes_explicit_none)
+
+    print("✓ test_filter_routes_by_isochrone_simplify_none: Default behavior preserved")
+
+
+def test_filter_routes_by_isochrone_simplify_applies(
+    mock_transit_routes, mock_transit_stops, mock_isochrone_small
+):
+    """Test that simplify parameter simplifies route geometries."""
+    routes_original, _ = filter_routes_by_isochrone(
+        mock_transit_routes,
+        mock_transit_stops,
+        mock_isochrone_small,
+        simplify=None,
+    )
+
+    routes_simplified, _ = filter_routes_by_isochrone(
+        mock_transit_routes,
+        mock_transit_stops,
+        mock_isochrone_small,
+        simplify=0.01,  # Large tolerance for testing
+    )
+
+    # Both should return same number of routes
+    assert len(routes_original) == len(routes_simplified)
+
+    # Geometry should be simplified (may have fewer coordinates)
+    # Note: For simple LineStrings, simplification might not always reduce points,
+    # but the operation should complete without error
+    assert isinstance(routes_simplified, gpd.GeoDataFrame)
+    assert "geometry" in routes_simplified.columns
+
+    print("✓ test_filter_routes_by_isochrone_simplify_applies: Simplification applied")
+
+
+def test_filter_routes_by_isochrone_simplify_doesnt_affect_stops(
+    mock_transit_routes, mock_transit_stops, mock_isochrone_small
+):
+    """Test that simplify doesn't affect stop geometries."""
+    _, stops_original = filter_routes_by_isochrone(
+        mock_transit_routes,
+        mock_transit_stops,
+        mock_isochrone_small,
+        simplify=None,
+    )
+
+    _, stops_with_simplify = filter_routes_by_isochrone(
+        mock_transit_routes,
+        mock_transit_stops,
+        mock_isochrone_small,
+        simplify=0.01,
+    )
+
+    # Stops should be identical (points don't get simplified)
+    assert len(stops_original) == len(stops_with_simplify)
+
+    # Check that geometries are the same
+    if len(stops_original) > 0:
+        # Use individual comparison for each geometry
+        for i in range(len(stops_original)):
+            assert stops_original.geometry.iloc[i].equals(
+                stops_with_simplify.geometry.iloc[i]
+            )
+
+    print(
+        "✓ test_filter_routes_by_isochrone_simplify_doesnt_affect_stops: Stops unchanged"
+    )
+
+
+def test_filter_routes_by_proximity_simplify(mock_transit_routes, mock_transit_stops):
+    """Test simplify parameter with proximity filtering."""
+    routes_original, _ = filter_routes_by_proximity(
+        mock_transit_routes,
+        mock_transit_stops,
+        center_lat=46.2035,
+        center_lon=6.1435,
+        radius=500.0,
+        simplify=None,
+    )
+
+    routes_simplified, _ = filter_routes_by_proximity(
+        mock_transit_routes,
+        mock_transit_stops,
+        center_lat=46.2035,
+        center_lon=6.1435,
+        radius=500.0,
+        simplify=0.01,
+    )
+
+    # Should return same number of routes
+    assert len(routes_original) == len(routes_simplified)
+
+    # Simplification should complete without error
+    assert isinstance(routes_simplified, gpd.GeoDataFrame)
+
+    print(
+        "✓ test_filter_routes_by_proximity_simplify: Simplification works with proximity filter"
+    )
 
 
 # ============================================================================


### PR DESCRIPTION
# Describe your changes

This PR adds proximity-based filtering of the routes, taking into account the distance from the center of the isochrone to identify routes

## Before

<img width="504" height="974" alt="image" src="https://github.com/user-attachments/assets/727dca53-06eb-4be8-9a76-1a3f84b3c79c" />

## After (500m radius)

<img width="504" height="974" alt="image" src="https://github.com/user-attachments/assets/b459e403-9510-4fe0-aa8c-b378a366d221" />

# Related GitHub issues and pull requests

- Ref: #
- Closes: #

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] Don't forget to link PR to issue if you are solving one.
